### PR TITLE
ValueError is also caught in depot load.

### DIFF
--- a/src/proctools/products/depot.py
+++ b/src/proctools/products/depot.py
@@ -79,7 +79,7 @@ class ProductDepot:
             for path in glob("*.xml"):
                 try:
                     product = DataProduct.from_file(path)
-                except (TypeError, ExpatError) as e:
+                except (TypeError, ExpatError, ValueError) as e:
                     self._log.warning(f"{e}; ignoring")
                     continue
                 type_ = product.type


### PR DESCRIPTION
ValueError added to the exceptions thrown by DataProduct.from_file which are caught in ProductDepot.load.

Closes #4 